### PR TITLE
[Fix] For imageWithContent support, we need to save icon content as well.

### DIFF
--- a/src/YMap.js
+++ b/src/YMap.js
@@ -129,6 +129,7 @@ export default {
                 };
 
                 if (props.icon && ['default#image', 'default#imageWithContent'].includes(props.icon.layout)) {
+                    marker.iconContent = props.icon.content;
                     marker.iconLayout = props.icon.layout;
                     marker.iconImageHref = props.icon.imageHref;
                     marker.iconImageSize = props.icon.imageSize;

--- a/src/YMap.js
+++ b/src/YMap.js
@@ -163,6 +163,7 @@ export default {
                 const properties = Object.assign(initialProps, balloonProps, m.properties);
 
                 const iconOptions = m.iconLayout ? {
+                    iconContent: m.iconContent,
                     iconLayout: m.iconLayout,
                     iconImageHref: m.iconImageHref,
                     iconImageSize: m.iconImageSize,


### PR DESCRIPTION
Hi @PNKBizz, at this time I've tried it on Yandex Sandbox.

Sandbox URL: https://tech.yandex.com/maps/jsbox/2.1/?from=techmapsmain

If you check line 37, you can see iconContent value and even if you set it as **undefined** there'll be no problem. Pass iconContent as a default sounds good.