### PR TITLE
Rc 0.9.17 - Добавление возможности использовать объект `ymaps` до создание карты

### DIFF
--- a/examples/Vue/src/App.vue
+++ b/examples/Vue/src/App.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="app">
     <yandex-map :coords="coords" @click="onClick">
-      <ymap-marker 
-        marker-id="123" 
+      <ymap-marker
+        marker-id="123"
         :coords="coords"
         :balloon-template="balloonTemplate"
       ></ymap-marker>
@@ -11,6 +11,7 @@
 </template>
 
 <script>
+
 export default {
   data: () => ({
     coords: [54, 39],
@@ -28,7 +29,9 @@ export default {
     onClick(e) {
       this.coords = e.get('coords');
     }
-  }  
+  },
+  mounted() {
+  }
 }
 </script>
 

--- a/examples/Vue/src/App.vue
+++ b/examples/Vue/src/App.vue
@@ -1,55 +1,62 @@
 <template>
-  <div id="app">
-    <yandex-map :coords="coords" @click="onClick">
-      <ymap-marker
-        marker-id="123"
-        :coords="coords"
-        :balloon-template="balloonTemplate"
-      ></ymap-marker>
-    </yandex-map>
-  </div>
+    <div id="app">
+        <yandex-map v-if="coords" :coords="coords" :zoom="12" @click="onClick">
+            <ymap-marker
+                marker-id="123"
+                :coords="coords"
+                :balloon-template="balloonTemplate"
+            ></ymap-marker>
+        </yandex-map>
+    </div>
 </template>
 
 <script>
-
-export default {
-  data: () => ({
-    coords: [54, 39],
-  }),
-  computed: {
-    balloonTemplate() {
-      return `
+    export default {
+        data: () => ({
+            coords: null,
+        }),
+        computed: {
+            balloonTemplate() {
+                return `
         <h1 class="red">Hi, everyone!</h1>
         <p>I am here: ${this.coords}</p>
         <img src="http://via.placeholder.com/350x150">
       `
+            }
+        },
+        methods: {
+            onClick(e) {
+                this.coords = e.get('coords');
+            }
+        },
+        mounted() {
+            this.$yMapLoad.yMapLoad()
+                .then(ymaps => {
+                    ymaps.geocode(`Москва, Красная площадь, 3`)
+                        .then(res => {
+                            const firstResult = res.geoObjects.get(0);
+                            this.coords = firstResult.geometry.getCoordinates();
+                        });
+                })
+        }
     }
-  },
-  methods: {
-    onClick(e) {
-      this.coords = e.get('coords');
-    }
-  },
-  mounted() {
-  }
-}
 </script>
 
 <style>
-#app {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  margin-top: 60px;
-}
+    #app {
+        font-family: 'Avenir', Helvetica, Arial, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        text-align: center;
+        color: #2c3e50;
+        margin-top: 60px;
+    }
 
-.ymap-container {
-  height: 600px;
-}
+    .ymap-container {
+        height: 600px;
+    }
 
-.red {
-  color: red;
-}
+    .red {
+        color: red;
+    }
 </style>

--- a/examples/Vue/src/main.js
+++ b/examples/Vue/src/main.js
@@ -1,17 +1,9 @@
 import Vue from 'vue'
 import App from './App.vue'
 import ymapPlugin from '../../../dist/vue-yandex-maps';
-import { ymapLoad } from '../../../dist/vue-yandex-maps';
 
-/*ymapLoad.yMapLoad()
-  .then(ymap => {
-    console.log(ymap)
-  })
-console.log(ymapLoad)
-console.log(ymapLoad.yMapLoad())*/
-
-Vue.config.productionTip = false
-Vue.use(ymapPlugin)
+Vue.config.productionTip = false;
+Vue.use(ymapPlugin, {apiKey: ''});
 
 new Vue({
   render: h => h(App),

--- a/examples/Vue/src/main.js
+++ b/examples/Vue/src/main.js
@@ -1,6 +1,14 @@
 import Vue from 'vue'
 import App from './App.vue'
 import ymapPlugin from '../../../dist/vue-yandex-maps';
+import { ymapLoad } from '../../../dist/vue-yandex-maps';
+
+/*ymapLoad.yMapLoad()
+  .then(ymap => {
+    console.log(ymap)
+  })
+console.log(ymapLoad)
+console.log(ymapLoad.yMapLoad())*/
 
 Vue.config.productionTip = false
 Vue.use(ymapPlugin)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-yandex-maps",
-  "version": "0.8.10",
+  "version": "0.8.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-yandex-maps",
-  "version": "0.8.17",
+  "version": "0.9.17",
   "description": "Yandex Maps component for VueJS.",
   "main": "dist/vue-yandex-maps.js",
   "unpkg": "dist/vue-yandex-maps.umd.js",

--- a/src/YMapLoad.js
+++ b/src/YMapLoad.js
@@ -1,49 +1,56 @@
-export default class CalculateService {
-  constructor() {
-    this.yandexMapScript = null;
-    this.scriptIsNotAttached = true;
-    this.ymapReady = false;
-    this.ymaps = null;
-  }
-
-  yMapLoad({mapLink, debug = false, settings = {}}, pluginOptions = {}) {
-    return new Promise((resolve, reject) => {
-      if (this.scriptIsNotAttached) {
-        this.yandexMapScript = document.createElement('SCRIPT');
-        const {
-          apiKey = '',
-          lang = 'ru_RU',
-          version = '2.1',
-          coordorder = 'latlong'
-        } = { ...pluginOptions, ...settings };
-        const mode = debug ? 'debug' : 'release';
-        const settings = `lang=${lang}${ apiKey && `&apikey=${apiKey}` }&mode=${mode}&coordorder=${coordorder}`
-        const mapLink = mapLink || `https://api-maps.yandex.ru/${version}/?${settings}`;
-        this.yandexMapScript.setAttribute('src', mapLink);
-        this.yandexMapScript.setAttribute('async', '');
-        this.yandexMapScript.setAttribute('defer', '');
-        document.body.appendChild(this.yandexMapScript);
-        this.scriptIsNotAttached = false;
-
-        this._eventLoadYandexMapScript()
-      }
-
-      if (this.ymapReady) {
-        this.ymaps.ready(() => resolve(this.ymaps));
-      } else {
-        this._eventLoadYandexMapScript (() => {
-          this.ymaps.ready(() => resolve(this.ymaps));
-        });
-      }
-    });
-  }
-
-  _eventLoadYandexMapScript (callback) {
-    this.yandexMapScript.onload = () => {
-      console.log(window.ymaps)
-      this.ymapReady = true;
-      this.ymaps = window.ymaps;
-      typeof callback === "function" && callback();
+export default class YMapLoad {
+    constructor() {
+        this._yandexMapScript = null;
+        this._scriptIsNotAttached = true;
+        this._ymapReady = false;
+        this._ymaps = null;
+        this._debug = false;
+        this._pluginOptions = {};
     }
-  }
+
+    yMapLoad(settings = {}) {
+        let mapLink;
+        if(typeof settings === "string") {
+            mapLink = settings
+        } else {
+            const {
+                apiKey = '',
+                lang = 'ru_RU',
+                version = '2.1',
+                coordorder = 'latlong'
+            } = {...this._pluginOptions, ...settings};
+            const mode = this._debug ? 'debug' : 'release';
+            const params = `lang=${lang}${apiKey && `&apikey=${apiKey}`}&mode=${mode}&coordorder=${coordorder}`
+            mapLink = `https://api-maps.yandex.ru/${version}/?${params}`;
+        }
+
+        return new Promise((resolve, reject) => {
+            if (this._scriptIsNotAttached) {
+                this._yandexMapScript = document.createElement('SCRIPT');
+                this._yandexMapScript.setAttribute('src', mapLink);
+                this._yandexMapScript.setAttribute('async', '');
+                this._yandexMapScript.setAttribute('defer', '');
+                document.body.appendChild(this._yandexMapScript);
+                this._scriptIsNotAttached = false;
+
+                this._eventLoadYandexMapScript()
+            }
+
+            if (this._ymapReady) {
+                this._ymaps.ready(() => resolve(this._ymaps));
+            } else {
+                this._eventLoadYandexMapScript(() => {
+                    this._ymaps.ready(() => resolve(this._ymaps));
+                });
+            }
+        });
+    }
+
+    _eventLoadYandexMapScript(callback) {
+        this._yandexMapScript.onload = () => {
+            this._ymapReady = true;
+            this._ymaps = window.ymaps;
+            typeof callback === "function" && callback();
+        }
+    }
 }

--- a/src/YMapLoad.js
+++ b/src/YMapLoad.js
@@ -1,0 +1,49 @@
+export default class CalculateService {
+  constructor() {
+    this.yandexMapScript = null;
+    this.scriptIsNotAttached = true;
+    this.ymapReady = false;
+    this.ymaps = null;
+  }
+
+  yMapLoad({mapLink, debug = false, settings = {}}, pluginOptions = {}) {
+    return new Promise((resolve, reject) => {
+      if (this.scriptIsNotAttached) {
+        this.yandexMapScript = document.createElement('SCRIPT');
+        const {
+          apiKey = '',
+          lang = 'ru_RU',
+          version = '2.1',
+          coordorder = 'latlong'
+        } = { ...pluginOptions, ...settings };
+        const mode = debug ? 'debug' : 'release';
+        const settings = `lang=${lang}${ apiKey && `&apikey=${apiKey}` }&mode=${mode}&coordorder=${coordorder}`
+        const mapLink = mapLink || `https://api-maps.yandex.ru/${version}/?${settings}`;
+        this.yandexMapScript.setAttribute('src', mapLink);
+        this.yandexMapScript.setAttribute('async', '');
+        this.yandexMapScript.setAttribute('defer', '');
+        document.body.appendChild(this.yandexMapScript);
+        this.scriptIsNotAttached = false;
+
+        this._eventLoadYandexMapScript()
+      }
+
+      if (this.ymapReady) {
+        this.ymaps.ready(() => resolve(this.ymaps));
+      } else {
+        this._eventLoadYandexMapScript (() => {
+          this.ymaps.ready(() => resolve(this.ymaps));
+        });
+      }
+    });
+  }
+
+  _eventLoadYandexMapScript (callback) {
+    this.yandexMapScript.onload = () => {
+      console.log(window.ymaps)
+      this.ymapReady = true;
+      this.ymaps = window.ymaps;
+      typeof callback === "function" && callback();
+    }
+  }
+}

--- a/src/YMapPlugin.js
+++ b/src/YMapPlugin.js
@@ -331,28 +331,21 @@ export default {
             { attributes: true, childList: true, characterData: true, subtree: false }
         );
 
-        if (this.ymapEventBus.scriptIsNotAttached) {
-            const yandexMapScript = document.createElement('SCRIPT');
-            const { 
-                apiKey = '', 
-                lang = 'ru_RU', 
-                version = '2.1', 
-                coordorder = 'latlong' 
-            } = { ...this.$options.pluginOptions, ...this.settings };
-            const mode = this.debug ? 'debug' : 'release';
-            const settings = `lang=${lang}${ apiKey && `&apikey=${apiKey}` }&mode=${mode}&coordorder=${coordorder}`
-            const mapLink = this.mapLink || `https://api-maps.yandex.ru/${version}/?${settings}`;
-            yandexMapScript.setAttribute('src', mapLink);
-            yandexMapScript.setAttribute('async', '');
-            yandexMapScript.setAttribute('defer', '');
-            document.body.appendChild(yandexMapScript);
-            this.ymapEventBus.scriptIsNotAttached = false;
-            yandexMapScript.onload = () => {
-                this.ymapEventBus.ymapReady = true;
-                this.ymapEventBus.$emit('scriptIsLoaded');
-            }
+        console.error(utils.yMapLoad)
+        if (utils.yMapLoad.scriptIsNotAttached) {
+          utils.yMapLoad.yMapLoad({
+            mapLink: this.mapLink,
+            debug: this.debug,
+            settings: this.settings
+          },
+            this.$options.pluginOptions)
+            .then(() => {
+              this.ymapEventBus.$emit('scriptIsLoaded');
+            })
         }
-        if (this.ymapEventBus.ymapReady) {
+
+        if (utils.yMapLoad.ymapReady) {
+            const ymaps = window.ymaps;
             ymaps.ready(this.init);
         } else {
             this.ymapEventBus.$on('scriptIsLoaded', () => {
@@ -360,6 +353,8 @@ export default {
                   this.myMap.geoObjects && this.myMap.geoObjects.removeAll();
                   this.setMarkers();
                 };
+
+                const ymaps = window.ymaps;
                 ymaps.ready(this.init);
             })
         }
@@ -367,5 +362,5 @@ export default {
     beforeDestroy() {
         this.myMap.geoObjects && this.myMap.geoObjects.removeAll();
         this.markerObserver.disconnect();
-    }
+    },
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
-import YMapPlugin from './YMap';
+//import YMapLoad from './YMapLoad';
+import YMapPlugin from './YMapPlugin';
 import Marker from './Marker';
+import { yMapLoad } from './utils';
 
 const install = function(Vue, options = {}) {
+  Vue.prototype.$yMapLoad = Vue.yMapLoad = yMapLoad;
   YMapPlugin.pluginOptions = options
   Vue.component('yandex-map', YMapPlugin);
   Vue.component('ymap-marker', Marker);
@@ -15,5 +18,6 @@ if (typeof window !== 'undefined' && window.Vue) {
 
 export const yandexMap = YMapPlugin;
 export const ymapMarker = Marker;
+export const ymapLoad = yMapLoad;
 
 export default YMapPlugin;

--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,24 @@
-//import YMapLoad from './YMapLoad';
-import YMapPlugin from './YMapPlugin';
-import Marker from './Marker';
+import YMapPlugin   from './YMapPlugin';
+import Marker       from './Marker';
 import { yMapLoad } from './utils';
 
-const install = function(Vue, options = {}) {
-  Vue.prototype.$yMapLoad = Vue.yMapLoad = yMapLoad;
-  YMapPlugin.pluginOptions = options
-  Vue.component('yandex-map', YMapPlugin);
-  Vue.component('ymap-marker', Marker);
+const install = function (Vue, options = {}) {
+    Vue.prototype.$yMapLoad = Vue.yMapLoad = yMapLoad;
+    yMapLoad._pluginOptions = YMapPlugin.pluginOptions = options;
+    Vue.component('yandex-map', YMapPlugin);
+    Vue.component('ymap-marker', Marker);
 };
 
 YMapPlugin.install = install;
 
 if (typeof window !== 'undefined' && window.Vue) {
-  window.Vue.use(YMapPlugin)
+    window.Vue.use(YMapPlugin)
 }
 
-export const yandexMap = YMapPlugin;
-export const ymapMarker = Marker;
-export const ymapLoad = yMapLoad;
+export {
+    YMapPlugin as yandexMap,
+    Marker as ymapMarker,
+    yMapLoad
+}
 
 export default YMapPlugin;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,7 @@
+import YMapLoad from './YMapLoad';
+
+export const yMapLoad = new YMapLoad();
+
 export function createCallbacks(callbacks, placemark) {
     if (callbacks && typeof callbacks === 'object') {
         for (let key in callbacks) {


### PR DESCRIPTION
Плагин экспортирует объект `yMapLoad` с публичным методом `yMapLoad`.
Метод принимает либо строку - адрес загрузки яндекс карт, например:
`https://api-maps.yandex.ru/2.1/?apikey=<ваш API-ключ>&lang=ru_RU`,
либо объект настройки, например:
```
{
    apiKey: '',
    lang: 'ru_RU',
    version: '2.1',
    coordorder: 'latlong'
}
```

К методу `yMapLoad` можно обращаться до отрисовки компонента <yandexMap>
для загрузки `ymaps` и возможности обратится к `ymaps.geocode`.
Метод возвращает promise, при успешном выполнении которого отдается 
объект `ymaps`.

При глобальном подключении плагина, к методу можно обратится через
`Vue.yMapLoad.yMapLoad()` или
`this.$yMapLoad.yMapLoad()` внутри компонента.

Примечание! Для тестирования функционала `ymaps.geocode` нужен `apiKey`