### PR TITLE
Move marker logic into marker component

### DIFF
--- a/src/Marker.js
+++ b/src/Marker.js
@@ -109,6 +109,8 @@ export default {
 
       this.$_marker = new ymaps[markerType](this.coords, properties, options);
 
+      this.$_marker.events.add('click', e => this.$emit('click', e));
+
       // Associate marker to map
       this.$_map.myMap.geoObjects.add(this.$_marker);
 

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -56,6 +56,8 @@ export default {
   methods: {
     init() {
       // Create marker
+      const markerType = utils.createMarkerType(this.markerType, this.$_map.useObjectManager)
+
       const initialProps = {
         hintContent: this.hintContent,
         iconContent: this.icon ? this.icon.content : null,
@@ -70,7 +72,42 @@ export default {
 
       const properties = Object.assign(initialProps, balloonProps, this.properties);
 
-      this.$_marker = new ymaps.Placemark(this.coords, properties, this.options);
+      const iconOptions = (this.icon && this.icon.layout) ? {
+        iconLayout: this.icon.layout,
+        iconImageHref: this.icon.imageHref,
+        iconImageSize: this.icon.imageSize,
+        iconImageOffset: this.icon.imageOffset,
+        iconContentOffset: this.icon.contentOffset,
+      } : { preset: this.icon && `islands#${utils.getIconPreset({ icon: this.icon })}Icon` };
+
+      if (this.icon && this.icon.layout && this.icon.contentLayout && typeof this.icon.contentLayout === 'string') {
+        iconOptions.iconContentLayout = ymaps.templateLayoutFactory
+          .createClass(this.icon.contentLayout);
+      }
+
+      const strokeOptions = this.markerStroke ? {
+        strokeColor: this.markerStroke.color || '0066ffff',
+        strokeOpacity: parseFloat(this.markerStroke.opacity) >= 0
+          ? parseFloat(this.markerStroke.opacity) : 1,
+        strokeStyle: this.markerStroke.style,
+        strokeWidth: parseFloat(this.markerStroke.width) >= 0 ? parseFloat(this.markerStroke.width) : 1,
+      } : {};
+
+      const fillOptions = this.markerFill ? {
+        fill: this.markerFill.enabled || true,
+        fillColor: this.markerFill.color || '0066ff99',
+        fillOpacity: parseFloat(this.markerFill.opacity) >= 0 ? parseFloat(this.markerFill.opacity) : 1,
+        fillImageHref: this.markerFill.imageHref || '',
+      } : {};
+
+      const options = Object.assign(
+        iconOptions,
+        strokeOptions,
+        fillOptions,
+        this.options,
+      );
+
+      this.$_marker = new ymaps[markerType](this.coords, properties, options);
 
       // Associate marker to map
       this.$_map.myMap.geoObjects.add(this.$_marker);

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -120,6 +120,11 @@ export default {
         objectManagerClusterize: this.$_map.objectManagerClusterize,
       };
       utils.addToMap([this.$_marker], config);*/
+    },
+    removeFromMap() {
+      if (this.$_marker) {
+        this.$_map.myMap.geoObjects.remove(this.$_marker);
+      }
     }
   },
   mounted() {
@@ -147,10 +152,21 @@ export default {
         this.init();
       });
     }
+
+    // Watch each prop to update marker
+    Object.keys(this.$props).forEach((prop) => {
+      this.$watch(
+        prop,
+        (newVal, oldVal) => {
+          if (!utils.objectComparison(newVal, oldVal)) {
+            this.removeFromMap();
+            this.init();
+          }
+        },
+      );
+    });
   },
   beforeDestroy () {
-    if (this.$_marker) {
-      this.$_map.myMap.geoObjects.remove(this.$_marker);
-    }
+    this.removeFromMap();
   },
 };

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -1,7 +1,5 @@
 import * as utils from './utils';
 
-const { emitter } = utils;
-
 const MARKER_TYPES = [
   'placemark',
   'polyline',
@@ -105,11 +103,11 @@ export default {
     this.$_map = $_findAncestor(a => a.$options.name === 'yandex-map');
 
     // Init marker when ymap is ready
-    if (emitter.ymapReady) {
-      ymaps.ready(this.init);
+    if (this.$_map.initialized) {
+      this.init();
     } else {
-      emitter.$on('scriptIsLoaded', () => {
-        ymaps.ready(this.init);
+      this.$_map.$on('map-was-initialized', () => {
+        this.init();
       });
     }
   },

--- a/src/YMap.js
+++ b/src/YMap.js
@@ -4,10 +4,12 @@ const { emitter } = utils;
 
 export default {
   pluginOptions: {},
+  name: 'yandex-map',
   data() {
     return {
       ymapId: `yandexMap${Math.round(Math.random() * 100000)}`,
       myMap: {},
+      initialized: false,
       style: this.ymapClass ? '' : 'width: 100%; height: 100%;',
     };
   },
@@ -203,6 +205,7 @@ export default {
 
       if (this.showAllMarkers) this.myMap.setBounds(this.myMap.geoObjects.getBounds());
 
+      this.initialized = true;
       this.$emit('map-was-initialized', this.myMap);
     },
   },


### PR DESCRIPTION
So this is a start to solve elegantly issues #183 #184 by moving marker logic into the marker component.

This is heavily inspired by https://github.com/Akryum/vue-googlemaps, credits to the authors !

So here is what I did :
- Removed `inject`/`provide` stuff for marker -> map communication
- Removed everything about slot markers in map component
- Added to the marker component a `$_map` reference to the parent map component, which is obtained in the component `mounted`
- Added to the marker component an `init` method which is called when the map is ready
This init function is very basic and still needs a lot of work:
- Some props are not used (and should be when creating the actual marker)
- ObjectManager mode is probably broken
- I wasn't sure if I should use utils to manipulate geoObjects so I did it manually to begin ; I think that using utils will create conflicts with map component `placemarks` prop

I think ideally the placemarks stuff in the map component could also be delegated to the marker component. The map could create marker components from the `placemarks` prop. This would avoid having the same code in Map and in Marker.

Hope this helps !