### PR TITLE
Fix duplicate map attaching & fix error window.__jsonp_ymaps_map is not a function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -196,7 +196,7 @@ export function createMarker(object, useObjectManager) {
 
 export function ymapLoader(settings = {}) {
   return new Promise((res, rej) => {
-    if (window.ymaps) return res();
+    if (window.ymaps || document.getElementById('vue-yandex-maps')) return res();
     const yandexMapScript = document.createElement('SCRIPT');
     const {
       apiKey = '',
@@ -211,7 +211,8 @@ export function ymapLoader(settings = {}) {
     yandexMapScript.setAttribute('src', link);
     yandexMapScript.setAttribute('async', '');
     yandexMapScript.setAttribute('defer', '');
-    document.body.appendChild(yandexMapScript);
+    yandexMapScript.setAttribute('id', 'vue-yandex-maps');
+    document.head.appendChild(yandexMapScript);
     emitter.scriptIsNotAttached = false;
     yandexMapScript.onload = () => {
       ymaps.ready(() => {


### PR DESCRIPTION
Если в компоненте подключать не только компонент карты, но и `loadYmap`, например так:
```js
import { yandexMap, ymapMarker, loadYmap } from 'vue-yandex-maps'
```
То инициализация карты будет производиться дважды и дважды добавляться скрипт (можно проверить добавив console.log в начало функции `ymapLoader`). От повторной инициализации карты также начинает вылетать ошибка в консоль:
```
Uncaught TypeError: window.__jsonp_ymaps_map is not a function
```

Этим PR подключение скрипта карты из конца `<body>` перемещено в конец `<head>` и добавляемому скрипту указываем атрибут `id`, по которому также проверяем при инициализации.

P.S.: Можно конечно настройку какой `id` присваивать вынести в `settings`, но там их деструктуризация уже после проверки сейчас и решил много не менять в PR.

REF: https://github.com/PNKBizz/vue-yandex-map/issues/83