### PR TITLE
Add routeButtonControl control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-yandex-maps",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-yandex-maps",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Yandex Maps component for VueJS.",
   "main": "dist/vue-yandex-maps.umd.js",
   "module": "dist/vue-yandex-maps.esm.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,6 +157,7 @@ const CONTROL_TYPES = [
   'trafficControl',
   'typeSelector',
   'zoomControl',
+  'routeButtonControl',
   'routePanelControl',
 ];
 


### PR DESCRIPTION
Исправление ошибки `[Vue warn]: Invalid prop: custom validator check failed for prop "controls".` при попытке добавить на карту контрол `routeButtonControl`. Данный контрол отутствует в объекте, который используется для валидации пропса с массивом контролов.

Взято отсюда: https://tech.yandex.ru/maps/jsapi/doc/2.1/ref/reference/control.Manager-docpage/#method_detail__add-param-control