### PR TITLE
Fix: Move balloon slot content to balloon layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-yandex-maps",
-  "version": "0.11.02",
+  "version": "0.11.05",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -100,6 +100,7 @@ export default {
       };
 
       let balloonContentLayout = null;
+      let balloonLayout = null;
 
       if (this.balloonTemplate) {
         balloonContentLayout = ymaps.templateLayoutFactory
@@ -107,7 +108,7 @@ export default {
       }
 
       if (this.$slots.balloon) {
-        balloonContentLayout = ymaps.templateLayoutFactory
+        balloonLayout = ymaps.templateLayoutFactory
           .createClass(this.$slots.balloon[0].elm.outerHTML);
       }
 
@@ -117,6 +118,10 @@ export default {
 
       if (balloonContentLayout != null) {
         marker.balloonOptions.balloonContentLayout = balloonContentLayout;
+      }
+
+      if (balloonLayout != null) {
+        marker.balloonOptions.balloonLayout = balloonLayout;
       }
 
       if (this.icon && ['default#image', 'default#imageWithContent'].includes(this.icon.layout)) {


### PR DESCRIPTION
Fixes https://github.com/PNKBizz/vue-yandex-map/issues/69
It's now available to fully customize balloon layout, not only template