### PR TITLE
Added built-in control sets

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -163,6 +163,9 @@ const CONTROL_TYPES = [
   'zoomControl',
   'routeButtonControl',
   'routePanelControl',
+  'smallMapDefaultSet',
+  'mediumMapDefaultSet',
+  'largeMapDefaultSet',
 ];
 
 export function controlsTypeValidator(val) {


### PR DESCRIPTION
https://yandex.ru/dev/maps/jsapi/doc/2.1/dg/concepts/controls.html#control-sets

Чтобы не добавлять все элементы управления по отдельности, можно использовать предустановленные наборы. В API включено три набора элементов управления: для больших карт (более 1000px в ширину), для стандартных карт (от 300 до 1000px в ширину) и для маленьких карт (менее 300px в ширину). Для отображения элементов управления из нужного набора достаточно указать ключ этого набора.