### PR TITLE
Добавил возможность кастомизации iconLayout

### DIFF
--- a/src/Marker.js
+++ b/src/Marker.js
@@ -67,7 +67,7 @@ export default {
   render(h) {
     return h('div', [
       this.$slots.balloon && h('div', { style: 'display: none;' }, [this.$slots.balloon]),
-      this.$slots.balloonLayout && h('div', { style: 'display: none;' }, [this.$slots.balloonLayout])
+      this.$slots.balloonLayout && h('div', { style: 'display: none;' }, [this.$slots.balloonLayout]),
     ]);
   },
   mounted() {
@@ -143,6 +143,8 @@ export default {
           marker.iconContentLayout = ymaps.templateLayoutFactory
             .createClass(this.icon.contentLayout);
         }
+      } else if (this.icon && typeof this.icon.layout === 'string') {
+        marker.iconLayout = ymaps.templateLayoutFactory.createClass(this.icon.layout);
       } else {
         marker.icon = this.icon;
       }


### PR DESCRIPTION
Привет, пытался сделать совершенно кастомный маркер (круглой формы). 

Нашёл как он делается с помощью яндекс карт. Увидел в исходном коде маркера, что contentLayout можно добавить через ymaps.templateLayoutFactory.createClass. Решил добавить такую возможность и для iconLayout. 
Проверил работоспособность изменив код в node_modules.
Возможно в данном условии нужно ещё проверять есть ли iconShape, чтобы задавать область клика на маркер при необходимости. 

P.S. Прошу прощения, если что не так - это мой первый pull request.