### PR TITLE
vue 3 - fix for 387 

### DIFF
--- a/src/YMap.js
+++ b/src/YMap.js
@@ -172,7 +172,7 @@ export default {
       // if ymap isn't initialized or have no markers;
       if (!window.ymaps
         || !ymaps.GeoObjectCollection
-        || (!this.initWithoutMarkers && !this.$slots.default() && !this.placemarks.length)
+        || (!this.initWithoutMarkers && !this.$slots.default && !this.placemarks.length)
       ) return;
 
       this.$emit('map-initialization-started');
@@ -304,7 +304,7 @@ export default {
         ),
         this.isReady && h(
           'div',
-          [this.$slots.default()],
+          [this.$slots.default],
         ),
       ],
     );

--- a/src/YMap.js
+++ b/src/YMap.js
@@ -287,27 +287,39 @@ export default {
     },
   },
   render() {
-    return h(
-      'section',
-      {
-        class: 'ymap-container',
-        ref: 'mapContainer',
-      },
-      [
-        h(
-          'div',
-          {
+    if (this.$slots.default) {
+      return h(
+        'section',
+        {
+          class: 'ymap-container',
+          ref: 'mapContainer',
+        },
+        [
+          h('div', {
             id: this.ymapId,
             class: this.ymapClass,
             style: this.style,
-          },
-        ),
-        this.isReady && h(
-          'div',
-          [this.$slots.default],
-        ),
-      ],
-    );
+          }),
+          this.isReady && h('div', [this.$slots.default]),
+        ]
+      );
+    } else {
+      return h(
+        'section',
+        {
+          class: 'ymap-container',
+          ref: 'mapContainer',
+        },
+        [
+          h('div', {
+            id: this.ymapId,
+            class: this.ymapClass,
+            style: this.style,
+          }),
+          this.isReady,
+        ]
+      );
+    }
   },
   mounted() {
     if (this.$attrs['map-link'] || this.$attrs.mapLink) throw new Error('Vue-yandex-maps: Attribute mapLink is not supported. Use settings.');


### PR DESCRIPTION
1. slots.default is a property, not a method. Fixed to avoid invalid builds for Vite and WebPack
2. Add an extra check for null/undefined