### PR TITLE
Remove Vue.use for vue3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,6 @@ const install = (Vue, options = {}) => {
 
 YMapPlugin.install = install;
 
-if (typeof window !== 'undefined' && window.Vue) {
-  window.Vue.use(YMapPlugin);
-}
-
 export const loadYmap = ymapLoader;
 export const yandexMap = YMapPlugin;
 export const ymapMarker = Marker;


### PR DESCRIPTION
Vue.use not supported in Vue3 Global API

Docs: https://v3-migration.vuejs.org/breaking-changes/global-api.html